### PR TITLE
Add flatlamp source to micado subpackage

### DIFF
--- a/scopesim_templates/micado/__init__.py
+++ b/scopesim_templates/micado/__init__.py
@@ -1,4 +1,8 @@
 from .darkness import darkness
 from .flatlamp import flatlamp
 
-__all__ = [darkness, flatlamp]
+# Include empty_sky for backwards compatibility reasons.
+# TODO: Remove empty_sky when it is not used in MicadoWISE anymore.
+empty_sky = darkness
+
+__all__ = [darkness, flatlamp, empty_sky]

--- a/scopesim_templates/micado/__init__.py
+++ b/scopesim_templates/micado/__init__.py
@@ -1,3 +1,4 @@
 from .darkness import darkness
+from .flatlamp import flatlamp
 
-__all__ = [darkness]
+__all__ = [darkness, flatlamp]

--- a/scopesim_templates/micado/__init__.py
+++ b/scopesim_templates/micado/__init__.py
@@ -1,3 +1,3 @@
-from .empty_sky import empty_sky
+from .darkness import darkness
 
-all = [empty_sky]
+__all__ = [darkness]

--- a/scopesim_templates/micado/darkness.py
+++ b/scopesim_templates/micado/darkness.py
@@ -1,0 +1,4 @@
+"""Empty sky template, used for dark measurements."""
+from ..basic.misc import empty_sky as darkness
+
+__all__ = [darkness]

--- a/scopesim_templates/micado/empty_sky.py
+++ b/scopesim_templates/micado/empty_sky.py
@@ -1,4 +1,0 @@
-"""Empty sky template, used for dark measurements."""
-from ..basic.misc import empty_sky
-
-all = [empty_sky]

--- a/scopesim_templates/micado/flatlamp.py
+++ b/scopesim_templates/micado/flatlamp.py
@@ -1,0 +1,11 @@
+"""Flat lamp for MICADO."""
+
+import numpy as np
+import scopesim
+
+
+def flatlamp():
+    """Create flat lamp source."""
+    return scopesim.Source(
+        x=[0], y=[0], ref=[0], spectra=np.array([1, 1]), lam=np.array([0.5, 2.5])
+    )

--- a/scopesim_templates/micado/flatlamp.py
+++ b/scopesim_templates/micado/flatlamp.py
@@ -11,7 +11,7 @@ def flatlamp(
         width=16.384,
         height=16.384,
         pixel_scale=1.024,
-        amplitude=100000.0,
+        amplitude=1000.0,
         fraction=0.9,
     ):
     """

--- a/scopesim_templates/micado/flatlamp.py
+++ b/scopesim_templates/micado/flatlamp.py
@@ -1,11 +1,85 @@
 """Flat lamp for MICADO."""
-
+import numpy
 import numpy as np
 import scopesim
+from astropy.io import fits
+from scopesim import Source
+import astropy.units as u
 
 
-def flatlamp():
-    """Create flat lamp source."""
-    return scopesim.Source(
-        x=[0], y=[0], ref=[0], spectra=np.array([1, 1]), lam=np.array([0.5, 2.5])
-    )
+def flatlamp(
+        width=16.384,
+        height=16.384,
+        pixel_scale=1.024,
+        amplitude=100000.0,
+        fraction=0.9,
+    ):
+    """
+    A flatlamp.
+
+    Default parameters selected such that:
+    - image is 16x16
+    - covering a single 4k by 4k detector.
+
+    Parameters
+    ----------
+    width : float
+        [arcsec] width of the 'screen'
+    height : float
+        [arcsec] width of the 'screen'
+    pixel_scale : float
+        [arcsec/pix] pixel scale
+    amplitude : float
+        [None] arbitrary scale factor
+    fraction : float
+        [None] fraction of flux at the edge
+
+    Returns
+    -------
+    src: scopesim.Source
+    """
+
+    # 16x16 by default
+    sx, sy = int(width / pixel_scale), int(height / pixel_scale)
+    ax = np.arange(sx)
+    ay = np.arange(sy)
+    xx, yy = np.meshgrid(ax, ay, sparse=True)
+
+    crpx = width // 2
+    crpy = height // 2
+
+    # * 1. is necessary for the normalization later
+    image = - ((xx - crpx) ** 2 + (yy - crpy) ** 2) * 1.
+
+    imin = image.min()
+    imax = image.max()
+    image = (1. - fraction) * (image - imin) / (imax - imin) + fraction
+    image *= amplitude
+
+    hdu = fits.ImageHDU(data=image)
+
+    hdu.header["CRPIX1"] = crpx
+    hdu.header["CRPIX2"] = crpy
+    hdu.header["CRVAL1"] = 0
+    hdu.header["CRVAL2"] = 0
+    hdu.header["CDELT1"] = pixel_scale / 3600
+    hdu.header["CDELT2"] = pixel_scale / 3600
+    hdu.header["CUNIT1"] = "DEG"
+    hdu.header["CUNIT2"] = "DEG"
+    hdu.header["CTYPE1"] = "RA---TAN"
+    hdu.header["CTYPE2"] = "DEC--TAN"
+
+    # number_of_points should be at least 200 or so
+    number_of_points = 230
+    sm = 1.2419516582773063
+    spectra = sm * np.ones(number_of_points)
+
+    sa = 1.0200000e+02
+    se = 3.3502039e+05
+    lam = numpy.logspace(numpy.log(sa), numpy.log(se), base=numpy.e, num=number_of_points) * u.Angstrom
+
+    return Source(
+            image_hdu=hdu,
+            spectra=spectra,
+            lam=lam,
+        )

--- a/scopesim_templates/tests/test_micado/test_darkness.py
+++ b/scopesim_templates/tests/test_micado/test_darkness.py
@@ -1,16 +1,16 @@
-"""Test for empty_sky."""
+"""Test for darkness."""
 from astropy.table import Table
 from synphot import SourceSpectrum
-from scopesim_templates.micado import empty_sky
+from scopesim_templates.micado import darkness
 from scopesim_templates.rc import Source
 
 
-class TestEmptySky:
-    """Test for empty_sky."""
+class TestDarkness:
+    """Test for darkness."""
 
-    def test_empty_sky_returns_source_object(self):
-        """Test for empty_sky."""
-        sky = empty_sky()
+    def test_darkness_returns_source_object(self):
+        """Test for darkness."""
+        sky = darkness()
         assert isinstance(sky, Source)
         assert isinstance(sky.spectra[0], SourceSpectrum)
         assert isinstance(sky.fields[0], Table)

--- a/scopesim_templates/tests/test_micado/test_flatlamp.py
+++ b/scopesim_templates/tests/test_micado/test_flatlamp.py
@@ -1,5 +1,5 @@
 """Test for flatlamp."""
-from astropy.table import Table
+from astropy.io.fits import ImageHDU
 from synphot import SourceSpectrum
 from scopesim_templates.micado import flatlamp
 from scopesim_templates.rc import Source
@@ -10,8 +10,7 @@ class TestFlatlamp:
 
     def test_flatlamp_returns_source_object(self):
         """Test for flatlamp."""
-        sky = flatlamp()
-        assert isinstance(sky, Source)
-        assert isinstance(sky.spectra[0], SourceSpectrum)
-        assert isinstance(sky.fields[0], Table)
-        assert sky.fields[0]["ref"][0] == 0
+        lamp = flatlamp()
+        assert isinstance(lamp, Source)
+        assert isinstance(lamp.spectra[0], SourceSpectrum)
+        assert isinstance(lamp.fields[0], ImageHDU)

--- a/scopesim_templates/tests/test_micado/test_flatlamp.py
+++ b/scopesim_templates/tests/test_micado/test_flatlamp.py
@@ -1,0 +1,17 @@
+"""Test for flatlamp."""
+from astropy.table import Table
+from synphot import SourceSpectrum
+from scopesim_templates.micado import flatlamp
+from scopesim_templates.rc import Source
+
+
+class TestFlatlamp:
+    """Test for flatlamp."""
+
+    def test_flatlamp_returns_source_object(self):
+        """Test for flatlamp."""
+        sky = flatlamp()
+        assert isinstance(sky, Source)
+        assert isinstance(sky.spectra[0], SourceSpectrum)
+        assert isinstance(sky.fields[0], Table)
+        assert sky.fields[0]["ref"][0] == 0


### PR DESCRIPTION
Add a flatlamp source to micado subpackage in order to simulate flat fields.

Also renames micado.empty_sky to micado.darkness, as that is actually what it should simulate.

Closes #4