### PR TITLE
Make docstring a rawstring to allow \propto

### DIFF
--- a/scopesim_templates/utils/imf.py
+++ b/scopesim_templates/utils/imf.py
@@ -293,7 +293,7 @@ class IMF(object):
         
     
 class IMF_broken_powerlaw(IMF):
-    """
+    r"""
     Initialize a multi-part power-law with N parts. Each part of the
     power-law is described with a probability density function:
 


### PR DESCRIPTION
Importing scopesim_templates gives this warning:
```
scopesim_templates/utils/imf.py:317: DeprecationWarning: invalid escape sequence \p
```
Which happens because there is a `\propto` in the docstrin of `IMF_broken_powerlaw`.
This PR makes the docstring of `IMF_broken_powerlaw` a raw string, which allows `\p`.