### PR TITLE
fixing inconsitency between stars and star source generating functions

### DIFF
--- a/scopesim_templates/basic/stars.py
+++ b/scopesim_templates/basic/stars.py
@@ -244,8 +244,7 @@ def stars(filter_name, amplitudes, spec_types, x, y):
 
 
 def star(filter_name, amplitude, spec_type="A0V", x=0, y=0):
-    src = stars(filter_name, [amplitude.value]*amplitude.unit,
-                [spec_type], [x], [y])
+    src = stars(filter_name, [amplitude], [spec_type], [x], [y])
     return src
 
 

--- a/scopesim_templates/tests/test_basic/test_stars.py
+++ b/scopesim_templates/tests/test_basic/test_stars.py
@@ -1,4 +1,4 @@
-import  pytest
+import pytest
 from pytest import approx
 
 import numpy as np
@@ -8,6 +8,28 @@ import synphot as sp
 from scopesim_templates.basic.stars import *
 from scopesim_templates.rc import ter_curve_utils as tcu
 from scopesim_templates.rc import Source
+
+
+def source_eq(source_lhs: Source, source_rhs: Source):
+    """hacky way to ensure two source"""
+    eq = len(source_lhs.spectra) == len(source_rhs.spectra)
+    for spectrum_lhs, spectrum_rhs in zip(source_lhs.spectra, source_rhs.spectra):
+        eq = eq and all(spectrum_lhs.waveset == spectrum_rhs.waveset)
+    return eq
+
+
+class TestStar:
+    def test_star_stars_equivalent(self):
+        """verify that star and stars yield the same object and have compatible interfaces"""
+        src_from_star = star("Generic/Johnson.V", 0, "A0V", 0, 0)
+        src_from_stars = stars("Generic/Johnson.V", [0], ["A0V"], [0], [0])
+        src_from_star_unit = star("Generic/Johnson.V", 0*u.mag, "A0V", 0, 0)
+        src_from_stars_unit = stars("Generic/Johnson.V", [0*u.mag], ["A0V"], [0], [0])
+
+        a = source_eq(src_from_star, src_from_stars)
+        assert(source_eq(src_from_star, src_from_stars))
+        assert(source_eq(src_from_star, src_from_star_unit))
+        assert(source_eq(src_from_star, src_from_stars_unit))
 
 
 class TestStars:


### PR DESCRIPTION
Just a small thing i noticed, `stars()` works with both Quantities and plain values, `star()` did not. Wrote test to verify that both work in both instances and produce the same result (which was a bit awkward, maybe can be skipped/done more elegantly)